### PR TITLE
Added in troubleshoot of python ssl cert failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ The output should look as follows.
 <img src="images/lib1.png" width="65%">
 </p>
 
+>**Troubleshooting:** If you observe `certificate verify failed: unable to get local issuer certificate` failure please review https://stackoverflow.com/a/57795811/7412781 
+
 Restart your IDE then navigate back to **"Tools -> Board"**, you'll now see the ESP32 board listed.
 
 <p align="center"> 


### PR DESCRIPTION
I had an issue of python ssl cert failure while running the script mentioned.
Python ssl did not use the certificates from `certifi`. For the people having similar problem as me, I proposed the troubleshoot.

I am not so sure why I am having the line 1503 change. I used web edit and maybe that's causing the problem. You can only merge in line 97.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
